### PR TITLE
Added response on freq request from Gpredict

### DIFF
--- a/SDRSharp.GpredictConnector/Rigctrld.cs
+++ b/SDRSharp.GpredictConnector/Rigctrld.cs
@@ -20,9 +20,15 @@ namespace SDRSharp.GpredictConnector
                         frequency_set_thread_ = new Thread(() => FrequencyInHzString = f_string);
                         frequency_set_thread_.Start();
                     }
+                    return "RPRT 0\\n";
                 }
+                return "RPRT -8\\n"; //wrong or unknown F command
             }
-            return "RPRT 0\n";
+            else if (command.StartsWith("f"))
+            {
+                return FrequencyInHzString + "\\n"; //return current freq.
+            }
+            return "RPRT -4\\n"; //recieved unsupported command
         }
 
         public long FrequencyInHz


### PR DESCRIPTION
Minor bug fix and added response to frequency from Gpredict. 
The connector should be stable now. (running for more than 48hours without a problem)
I've also compiled the latest Gpredict version for Windows so the log from Gpredict isn't flooded with error messages anymore. See https://github.com/Jansemar/Gpredict_win32
